### PR TITLE
agent: test: add max_signals_per_minute limit to signal-engine config

### DIFF
--- a/services/signal-engine-service/go.mod
+++ b/services/signal-engine-service/go.mod
@@ -1,0 +1,7 @@
+module signal-engine-service
+
+go 1.22
+
+require go.uber.org/zap v1.27.0
+
+require go.uber.org/multierr v1.10.0 // indirect

--- a/services/signal-engine-service/go.sum
+++ b/services/signal-engine-service/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/services/signal-engine-service/internal/application/publisher.go
+++ b/services/signal-engine-service/internal/application/publisher.go
@@ -1,0 +1,46 @@
+package application
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"signal-engine-service/internal/domain"
+)
+
+// SignalPublisher controls signal emission to the signals.generated subject,
+// enforcing the configured rate limit before delegating to the underlying
+// publish function.
+type SignalPublisher struct {
+	rateLimiter domain.RateLimiter
+	logger      *zap.Logger
+}
+
+// NewSignalPublisher creates a SignalPublisher.
+// rateLimiter must not be nil; use domain.NewSignalRateLimiter(0) to disable rate limiting.
+func NewSignalPublisher(rateLimiter domain.RateLimiter, logger *zap.Logger) *SignalPublisher {
+	return &SignalPublisher{
+		rateLimiter: rateLimiter,
+		logger:      logger,
+	}
+}
+
+// Publish emits a signal by calling publishFn if the rate limit allows.
+// Returns (true, nil) on successful emission, (false, nil) when the signal is
+// dropped due to rate limiting, or (false, err) on a publish error.
+//
+// eventID is used for log correlation when a signal is dropped.
+func (p *SignalPublisher) Publish(ctx context.Context, eventID string, publishFn func() error) (bool, error) {
+	if !p.rateLimiter.Allow() {
+		p.logger.Debug("signal dropped: rate limit exceeded",
+			zap.String("event_id", eventID),
+		)
+		return false, nil
+	}
+
+	if err := publishFn(); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/services/signal-engine-service/internal/application/publisher_test.go
+++ b/services/signal-engine-service/internal/application/publisher_test.go
@@ -1,0 +1,122 @@
+package application
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"signal-engine-service/internal/domain"
+)
+
+// countingLimiter is a test double that denies after max calls.
+type countingLimiter struct {
+	max  int
+	seen int
+}
+
+func (l *countingLimiter) Allow() bool {
+	if l.seen >= l.max {
+		return false
+	}
+	l.seen++
+	return true
+}
+
+// fixedClock returns a constant time, satisfying domain.Clock.
+type fixedClock struct{ t time.Time }
+
+func (c fixedClock) Now() time.Time { return c.t }
+
+func nopLogger() *zap.Logger { return zap.NewNop() }
+
+// --- rate limiting integration ---
+
+func TestPublish_DropsWhenRateLimitExceeded(t *testing.T) {
+	limiter := &countingLimiter{max: 2}
+	pub := NewSignalPublisher(limiter, nopLogger())
+
+	ctx := context.Background()
+	called := 0
+	fn := func() error { called++; return nil }
+
+	// First two calls should succeed.
+	for i := 0; i < 2; i++ {
+		ok, err := pub.Publish(ctx, "evt-1", fn)
+		if err != nil {
+			t.Fatalf("unexpected error on call %d: %v", i+1, err)
+		}
+		if !ok {
+			t.Fatalf("expected emission on call %d", i+1)
+		}
+	}
+
+	// Third call should be dropped.
+	ok, err := pub.Publish(ctx, "evt-1", fn)
+	if err != nil {
+		t.Fatalf("unexpected error on dropped call: %v", err)
+	}
+	if ok {
+		t.Fatal("expected Publish to return false when rate limited")
+	}
+	if called != 2 {
+		t.Errorf("expected publishFn called 2 times, got %d", called)
+	}
+}
+
+func TestPublish_NoRateLimit_AllowsAll(t *testing.T) {
+	rl := domain.NewSignalRateLimiter(0) // disabled
+	pub := NewSignalPublisher(rl, nopLogger())
+
+	ctx := context.Background()
+	called := 0
+	fn := func() error { called++; return nil }
+
+	const n = 200
+	for i := 0; i < n; i++ {
+		ok, err := pub.Publish(ctx, "evt-x", fn)
+		if err != nil {
+			t.Fatalf("unexpected error on call %d: %v", i+1, err)
+		}
+		if !ok {
+			t.Fatalf("expected emission on call %d with limit=0", i+1)
+		}
+	}
+	if called != n {
+		t.Errorf("expected publishFn called %d times, got %d", n, called)
+	}
+}
+
+func TestPublish_PropagatesPublishError(t *testing.T) {
+	rl := domain.NewSignalRateLimiter(0)
+	pub := NewSignalPublisher(rl, nopLogger())
+
+	want := errors.New("nats unavailable")
+	ok, err := pub.Publish(context.Background(), "evt-err", func() error { return want })
+	if ok {
+		t.Fatal("expected ok=false on publish error")
+	}
+	if !errors.Is(err, want) {
+		t.Fatalf("expected wrapped error, got %v", err)
+	}
+}
+
+func TestPublish_WithDomainLimiter_DropsExcess(t *testing.T) {
+	clk := fixedClock{t: time.Now()}
+	rl := domain.NewSignalRateLimiterWithClock(3, clk)
+	pub := NewSignalPublisher(rl, nopLogger())
+
+	ctx := context.Background()
+	allowed := 0
+	fn := func() error { allowed++; return nil }
+
+	for i := 0; i < 6; i++ {
+		pub.Publish(ctx, "evt-2", fn) //nolint:errcheck
+	}
+
+	if allowed != 3 {
+		t.Errorf("expected 3 allowed signals with limit=3, got %d", allowed)
+	}
+}

--- a/services/signal-engine-service/internal/config/config.go
+++ b/services/signal-engine-service/internal/config/config.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// Config holds signal-engine-service configuration.
+type Config struct {
+	// NATSUrl is the NATS server connection URL.
+	NATSUrl string
+
+	// MaxSignalsPerMinute controls the maximum number of signals emitted per minute.
+	// Set to 0 (default) to disable rate limiting.
+	//
+	// NOTE: For deterministic replay/backfill operations, this must be set to 0.
+	// A non-zero value may cause replay to produce different outputs than the
+	// original run, violating the platform invariant of deterministic replay.
+	MaxSignalsPerMinute int
+}
+
+// Load reads configuration from environment variables, applying defaults.
+func Load() (*Config, error) {
+	cfg := &Config{
+		NATSUrl:             getEnv("NATS_URL", "nats://localhost:4222"),
+		MaxSignalsPerMinute: 0,
+	}
+
+	if v := os.Getenv("SIGNAL_ENGINE_MAX_SIGNALS_PER_MINUTE"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid SIGNAL_ENGINE_MAX_SIGNALS_PER_MINUTE %q: %w", v, err)
+		}
+		cfg.MaxSignalsPerMinute = n
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+// Validate checks that all configuration values are acceptable.
+func (c *Config) Validate() error {
+	if c.MaxSignalsPerMinute < 0 {
+		return errors.New("MaxSignalsPerMinute must be >= 0")
+	}
+	return nil
+}
+
+func getEnv(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/services/signal-engine-service/internal/config/config_test.go
+++ b/services/signal-engine-service/internal/config/config_test.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestLoad_Defaults(t *testing.T) {
+	t.Setenv("NATS_URL", "")
+	t.Setenv("SIGNAL_ENGINE_MAX_SIGNALS_PER_MINUTE", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MaxSignalsPerMinute != 0 {
+		t.Errorf("expected MaxSignalsPerMinute=0, got %d", cfg.MaxSignalsPerMinute)
+	}
+	if cfg.NATSUrl != "nats://localhost:4222" {
+		t.Errorf("expected default NATSUrl, got %q", cfg.NATSUrl)
+	}
+}
+
+func TestLoad_MaxSignalsPerMinute(t *testing.T) {
+	t.Setenv("SIGNAL_ENGINE_MAX_SIGNALS_PER_MINUTE", "100")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MaxSignalsPerMinute != 100 {
+		t.Errorf("expected MaxSignalsPerMinute=100, got %d", cfg.MaxSignalsPerMinute)
+	}
+}
+
+func TestLoad_MaxSignalsPerMinute_Zero(t *testing.T) {
+	t.Setenv("SIGNAL_ENGINE_MAX_SIGNALS_PER_MINUTE", "0")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MaxSignalsPerMinute != 0 {
+		t.Errorf("expected MaxSignalsPerMinute=0, got %d", cfg.MaxSignalsPerMinute)
+	}
+}
+
+func TestLoad_MaxSignalsPerMinute_Negative(t *testing.T) {
+	t.Setenv("SIGNAL_ENGINE_MAX_SIGNALS_PER_MINUTE", "-1")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for negative MaxSignalsPerMinute, got nil")
+	}
+}
+
+func TestLoad_MaxSignalsPerMinute_Invalid(t *testing.T) {
+	t.Setenv("SIGNAL_ENGINE_MAX_SIGNALS_PER_MINUTE", "not-a-number")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for invalid MaxSignalsPerMinute, got nil")
+	}
+}
+
+func TestValidate_Negative(t *testing.T) {
+	cfg := &Config{MaxSignalsPerMinute: -5}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected validation error for negative value")
+	}
+}
+
+func TestValidate_Zero(t *testing.T) {
+	cfg := &Config{MaxSignalsPerMinute: 0}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("unexpected error for zero value: %v", err)
+	}
+}
+
+func TestValidate_Positive(t *testing.T) {
+	cfg := &Config{MaxSignalsPerMinute: 60}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("unexpected error for positive value: %v", err)
+	}
+}

--- a/services/signal-engine-service/internal/domain/ratelimiter.go
+++ b/services/signal-engine-service/internal/domain/ratelimiter.go
@@ -1,0 +1,82 @@
+package domain
+
+import (
+	"sync"
+	"time"
+)
+
+// RateLimiter controls whether a signal emission is allowed.
+// Implementations must be safe for concurrent use.
+type RateLimiter interface {
+	Allow() bool
+}
+
+// Clock abstracts wall-clock time to allow deterministic testing.
+type Clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+
+// noopLimiter always permits (used when MaxSignalsPerMinute == 0).
+type noopLimiter struct{}
+
+func (noopLimiter) Allow() bool { return true }
+
+// slidingWindowLimiter counts signal timestamps within the last minute.
+// It is safe for concurrent use.
+type slidingWindowLimiter struct {
+	mu           sync.Mutex
+	maxPerMinute int
+	clock        Clock
+	timestamps   []time.Time
+}
+
+// NewSignalRateLimiter creates a RateLimiter that allows at most maxPerMinute
+// signals per 60-second sliding window.
+//
+// If maxPerMinute <= 0, a no-op limiter is returned that always allows.
+func NewSignalRateLimiter(maxPerMinute int) RateLimiter {
+	return NewSignalRateLimiterWithClock(maxPerMinute, realClock{})
+}
+
+// NewSignalRateLimiterWithClock is like NewSignalRateLimiter but accepts an
+// injectable Clock for deterministic testing.
+func NewSignalRateLimiterWithClock(maxPerMinute int, clock Clock) RateLimiter {
+	if maxPerMinute <= 0 {
+		return noopLimiter{}
+	}
+	return &slidingWindowLimiter{
+		maxPerMinute: maxPerMinute,
+		clock:        clock,
+		timestamps:   make([]time.Time, 0, maxPerMinute),
+	}
+}
+
+// Allow reports whether a signal may be emitted.
+// It returns false when the sliding-window count has reached maxPerMinute.
+func (l *slidingWindowLimiter) Allow() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := l.clock.Now()
+	windowStart := now.Add(-time.Minute)
+
+	// Evict timestamps outside the 1-minute window (re-use backing array).
+	valid := l.timestamps[:0]
+	for _, t := range l.timestamps {
+		if t.After(windowStart) {
+			valid = append(valid, t)
+		}
+	}
+	l.timestamps = valid
+
+	if len(l.timestamps) >= l.maxPerMinute {
+		return false
+	}
+
+	l.timestamps = append(l.timestamps, now)
+	return true
+}

--- a/services/signal-engine-service/internal/domain/ratelimiter_test.go
+++ b/services/signal-engine-service/internal/domain/ratelimiter_test.go
@@ -1,0 +1,172 @@
+package domain
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// fixedClock is a Clock implementation whose time can be advanced manually.
+type fixedClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newFixedClock(t time.Time) *fixedClock { return &fixedClock{now: t} }
+
+func (c *fixedClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fixedClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+// --- no-op limiter (zero / negative maxPerMinute) ---
+
+func TestNewSignalRateLimiter_Zero_AlwaysAllows(t *testing.T) {
+	rl := NewSignalRateLimiter(0)
+	for i := 0; i < 1000; i++ {
+		if !rl.Allow() {
+			t.Fatalf("expected Allow()=true on call %d with limit=0", i)
+		}
+	}
+}
+
+func TestNewSignalRateLimiter_Negative_AlwaysAllows(t *testing.T) {
+	rl := NewSignalRateLimiter(-10)
+	for i := 0; i < 100; i++ {
+		if !rl.Allow() {
+			t.Fatalf("expected Allow()=true on call %d with limit=-10", i)
+		}
+	}
+}
+
+// --- sliding window: basic allowance ---
+
+func TestSlidingWindow_AllowsUpToLimit(t *testing.T) {
+	clk := newFixedClock(time.Now())
+	rl := NewSignalRateLimiterWithClock(5, clk)
+
+	for i := 0; i < 5; i++ {
+		if !rl.Allow() {
+			t.Fatalf("expected Allow()=true on call %d (limit=5)", i+1)
+		}
+	}
+}
+
+func TestSlidingWindow_DropsOverLimit(t *testing.T) {
+	clk := newFixedClock(time.Now())
+	rl := NewSignalRateLimiterWithClock(3, clk)
+
+	// Consume the full quota.
+	for i := 0; i < 3; i++ {
+		rl.Allow()
+	}
+
+	// Next call must be denied.
+	if rl.Allow() {
+		t.Fatal("expected Allow()=false after limit reached")
+	}
+}
+
+func TestSlidingWindow_ExactlyAtLimit(t *testing.T) {
+	clk := newFixedClock(time.Now())
+	const limit = 10
+	rl := NewSignalRateLimiterWithClock(limit, clk)
+
+	allowed := 0
+	for i := 0; i < limit+5; i++ {
+		if rl.Allow() {
+			allowed++
+		}
+	}
+	if allowed != limit {
+		t.Errorf("expected %d allowed signals, got %d", limit, allowed)
+	}
+}
+
+// --- sliding window: window reset ---
+
+func TestSlidingWindow_ResetsAfterMinute(t *testing.T) {
+	clk := newFixedClock(time.Now())
+	rl := NewSignalRateLimiterWithClock(3, clk)
+
+	// Exhaust quota.
+	for i := 0; i < 3; i++ {
+		rl.Allow()
+	}
+	if rl.Allow() {
+		t.Fatal("expected drop before window reset")
+	}
+
+	// Advance past the 1-minute window.
+	clk.Advance(61 * time.Second)
+
+	// Quota should be replenished.
+	if !rl.Allow() {
+		t.Fatal("expected Allow()=true after window reset")
+	}
+}
+
+func TestSlidingWindow_PartialReset(t *testing.T) {
+	base := time.Now()
+	clk := newFixedClock(base)
+	rl := NewSignalRateLimiterWithClock(3, clk)
+
+	// Emit 2 signals at t=0.
+	rl.Allow()
+	rl.Allow()
+
+	// Advance 61 seconds — first 2 timestamps fall outside window.
+	clk.Advance(61 * time.Second)
+
+	// Emit 1 more at t=61s (within fresh window).
+	rl.Allow()
+
+	// Now we should have capacity for 2 more (3 - 1 = 2).
+	if !rl.Allow() {
+		t.Fatal("expected Allow()=true: only 1 signal in window")
+	}
+	if !rl.Allow() {
+		t.Fatal("expected Allow()=true: only 2 signals in window")
+	}
+	// Third in the new window should be denied (limit=3 and we have 3).
+	if rl.Allow() {
+		t.Fatal("expected Allow()=false: 3 signals already in window")
+	}
+}
+
+// --- concurrency safety ---
+
+func TestSlidingWindow_ConcurrentAccess(t *testing.T) {
+	clk := newFixedClock(time.Now())
+	const limit = 50
+	rl := NewSignalRateLimiterWithClock(limit, clk)
+
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		allowed int
+	)
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if rl.Allow() {
+				mu.Lock()
+				allowed++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if allowed > limit {
+		t.Errorf("concurrent: allowed %d signals, expected <= %d", allowed, limit)
+	}
+}


### PR DESCRIPTION
Closes #3

Implemented by developer-agent via Claude Code.

### Plan Summary

# Implementation Plan — GH-3

## Objective

Add a configurable `MaxSignalsPerMinute` rate limit to the signal-engine-service that controls the maximum number of signals emitted per minute. When the limit is reached, excess signals are dropped. When set to 0, rate limiting is disabled.

## Scope

- Add `MaxSignalsPerMinute int` field to signal-engine configuration struct
- Implement in-memory token-bucket or sliding-window counter for rate limiting
- Integrate rate limiter into signal emission path
- Add unit tests for rate limiting behavior
- Ensure existing tests remain passing

## Out of scope

- Protobuf contract changes (not required per task constraints)
- Queueing/buffering of excess signals (dropping is acceptable per AC)
- Distributed rate limiting across instances (in-memory is explicitly allowed)
- Metrics/observability for dropped signals (not in AC, can be follow-up)
- Persistence of rate limit state across restarts

## Bounded contexts impacted

| Context | Impact |